### PR TITLE
Use template_release on linux to fix a crash with release exports

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -46,23 +46,8 @@ jobs:
             { platform: windows, arch: x86_64, os: ubuntu-latest },
             { platform: macos, arch: universal, os: macos-latest },
           ]
-        target-type: [template_debug]
+        target-type: [template_debug, template_release]
         float-precision: [single]
-        # Only build template_release on linux. release mode template exports can't use
-        # template_debug on linux but can on other platforms.
-        include:
-          - target:
-              platform: linux
-              arch: x86_64
-              os: ubuntu-22.04
-            target-type: template_release
-            float-precision: single
-          - target:
-              platform: linux
-              arch: arm64
-              os: ubuntu-22.04-arm
-            target-type: template_release
-            float-precision: single
 
     runs-on: ${{ matrix.target.os }}
     steps:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -48,6 +48,21 @@ jobs:
           ]
         target-type: [template_debug]
         float-precision: [single]
+        # Only build template_release on linux. release mode template exports can't use
+        # template_debug on linux but can on other platforms.
+        include:
+          - target:
+              platform: linux
+              arch: x86_64
+              os: ubuntu-22.04
+            target-type: template_release
+            float-precision: single
+          - target:
+              platform: linux
+              arch: arm64
+              os: ubuntu-22.04-arm
+            target-type: template_release
+            float-precision: single
 
     runs-on: ${{ matrix.target.os }}
     steps:

--- a/project/addons/godot-ndi/godot-ndi.gdextension
+++ b/project/addons/godot-ndi/godot-ndi.gdextension
@@ -11,8 +11,11 @@ linux.arm64.single.debug = "bin/linux/libgodot-ndi.linux.template_debug.arm64.so
 linux.x86_64.single.release = "bin/linux/libgodot-ndi.linux.template_release.x86_64.so"
 linux.arm64.single.release = "bin/linux/libgodot-ndi.linux.template_release.arm64.so"
 
-windows.x86_64.single = "bin/windows/libgodot-ndi.windows.template_debug.x86_64.dll"
-macos.single = "bin/macos/libgodot-ndi.macos.template_debug.universal.dylib"
+windows.x86_64.single.debug = "bin/windows/libgodot-ndi.windows.template_debug.x86_64.dll"
+windows.x86_64.single.release = "bin/windows/libgodot-ndi.windows.template_release.x86_64.dll"
+
+macos.single.debug = "bin/macos/libgodot-ndi.macos.template_debug.universal.dylib"
+macos.single.release = "bin/macos/libgodot-ndi.macos.template_release.universal.dylib"
 
 [icons]
 

--- a/project/addons/godot-ndi/godot-ndi.gdextension
+++ b/project/addons/godot-ndi/godot-ndi.gdextension
@@ -6,8 +6,11 @@ reloadable = false
 
 [libraries]
 
-linux.x86_64.single = "bin/linux/libgodot-ndi.linux.template_debug.x86_64.so"
-linux.arm64.single = "bin/linux/libgodot-ndi.linux.template_debug.arm64.so"
+linux.x86_64.single.debug = "bin/linux/libgodot-ndi.linux.template_debug.x86_64.so"
+linux.arm64.single.debug = "bin/linux/libgodot-ndi.linux.template_debug.arm64.so"
+linux.x86_64.single.release = "bin/linux/libgodot-ndi.linux.template_release.x86_64.so"
+linux.arm64.single.release = "bin/linux/libgodot-ndi.linux.template_release.arm64.so"
+
 windows.x86_64.single = "bin/windows/libgodot-ndi.windows.template_debug.x86_64.dll"
 macos.single = "bin/macos/libgodot-ndi.macos.template_debug.universal.dylib"
 


### PR DESCRIPTION
Fixes issue this issue https://github.com/unvermuthet/godot-ndi/issues/42

Modifies the `.gdextension` file to use `template_release` when exporting a project in release mode on linux.

Also adds linux `template_release` builds to the CI.

The sample app now displays an image in release mode before crashing. It also crashes in debug mode so I think its a separate issue.